### PR TITLE
url.parse can parse querystrings as well.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const qs = require('querystring')
 const url = require('url')
 const fmw = require('find-my-way')
 
@@ -13,7 +12,7 @@ function router (options) {
 function enhancer (fn) {
   return function (req, res, params, store) {
     req.params = params
-    req.query = qs.parse(url.parse(req.url).query)
+    req.query = url.parse(req.url, true).query
     return fn(req, res, store)
   }
 }


### PR DESCRIPTION
According to [Node.js documentation](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost), You can pass `true` as the second argument to `url.parse` and it will use `querystring` module to parse the query into an object.

```sh
> npm test

> micro-fork@2.0.0 test /Users/faizaan.m/Developer/micro-fork
> tap test/*.spec.js --reporter spec --coverage


test/index.spec.js
  Exports right api types
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal
    ✓ should be equal

  ✓ Response to GET:/ping with 200
  ✓ Response to POST:/users with 200
  ✓ Response to DELETE:/users/123 with 200
  ✓ Response to GET:/users?age=20 with 200
  ✓ Response to unmatched route with 404

  13 passing (2s)
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |    85.19 |      100 |    69.23 |      100 |                   |
 index.js |    85.19 |      100 |    69.23 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|
```