### PR TITLE
WHATWG URL API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "8"
+  # - "8"
   - "10"
   - "12"

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const url = require('url')
+const querystring = require('querystring')
 const fmw = require('find-my-way')
 
 function router (options) {
@@ -12,7 +12,7 @@ function router (options) {
 function enhancer (fn) {
   return function (req, res, params, store) {
     req.params = params
-    req.query = url.parse(req.url, true).query
+    req.query = querystring.parse(new URL(req.url, `http://${req.headers.host}`).searchParams.toString())
     return fn(req, res, store)
   }
 }


### PR DESCRIPTION
Hello,

since `node 10` is approaching the end of ACTIVE LTS status, I've got rid of the [deprecated](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_legacy_url_api) (in node 12) `url.parse` in favor of the WHATWG standards... well, almost.

In order **not** to break the API, `req.query` parameters can still be accessed as `req.query.xxx`. Unfortunately, support for `node 8` should be dropped... Maybe you want to keep this PR for another 3 months until `node 8` goes END of LIFE.

In the future, they should be accessed using the [URLSearchParams](https://nodejs.org/dist/latest-v12.x/docs/api/url.html#url_class_urlsearchparams) class methods, for example:
`req.query.get('xxx')`. This way you could remove `querystring` and do something like

```js
req.query = new URL(req.url, `http://${req.headers.host}`).searchParams
```

By the way, your no frills super-fast router is awesome.